### PR TITLE
Adds support for pushing ssp eregs via dockerimage

### DIFF
--- a/Dockerfile.cf
+++ b/Dockerfile.cf
@@ -1,0 +1,67 @@
+FROM python:2.7
+
+#---- Begin Node setup ----
+
+# gpg keys listed at https://github.com/nodejs/node
+RUN set -ex \
+  && for key in \
+    9554F04D7259F04124DE6B476D5A82AC7E37093B \
+    94AE36675C464D64BAFA68DD7434390BDBE9B9C5 \
+    0034A06D9D9B0064CE8ADF6BF1747F4AD2306D93 \
+    FD3A5288F042B6850C66B31F09FE44734EB7990E \
+    71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 \
+    DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
+    B9AE9905FFD7803F25714661B63B535A4C206CA9 \
+    C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
+  ; do \
+    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
+  done
+
+ENV NPM_CONFIG_LOGLEVEL info
+ENV NODE_VERSION 4.6.0
+
+RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.xz" \
+  && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
+  && gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc \
+  && grep " node-v$NODE_VERSION-linux-x64.tar.xz\$" SHASUMS256.txt | sha256sum -c - \
+  && tar -xJf "node-v$NODE_VERSION-linux-x64.tar.xz" -C /usr/local --strip-components=1 \
+  && rm "node-v$NODE_VERSION-linux-x64.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
+&& ln -s /usr/local/bin/node /usr/local/bin/nodejs
+
+#---- End Node setup ----
+
+RUN npm install -g grunt-cli
+
+# Need git for eregs dependencies, ruby/sass for frontend
+RUN apt-get update \
+    && apt-get -y install git ruby \
+    && gem install sass \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV PYTHONUNBUFFERED="1" \
+    DATABASE_URL="sqlite:////app/db/db.sqlite" \
+    PATH="$PATH:."
+
+# Requirements
+COPY ["requirements/web.txt", "/app/src/requirements.txt"]
+WORKDIR /app/src
+RUN pip install --no-cache-dir -r requirements.txt
+
+# (indirectly) install the Node dependencies so they are cached in a layer
+COPY ["manage.py", "/app/src/"]
+COPY ["atf_eregs/__init__.py", "/app/src/atf_eregs/"]
+COPY ["atf_eregs/settings/", "/app/src/atf_eregs/settings/"]
+RUN ["manage.py", "compile_frontend"]
+
+# Then the UI files
+COPY ["atf_eregs", "/app/src/atf_eregs"]
+
+# And compile them
+RUN ["manage.py", "compile_frontend"]
+
+RUN mkdir -p /app/db && chmod 777 /app/db
+RUN bash -c "manage.py migrate"
+# VOLUME "/app/db"
+EXPOSE 8000
+
+ENTRYPOINT bash -c "manage.py runserver 0.0.0.0:8080"

--- a/Dockerfile.cf
+++ b/Dockerfile.cf
@@ -64,4 +64,4 @@ RUN bash -c "manage.py migrate"
 # VOLUME "/app/db"
 EXPOSE 8000
 
-ENTRYPOINT bash -c "manage.py runserver 0.0.0.0:8080"
+ENTRYPOINT bash -c "manage.py runserver 0.0.0.0:8000"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,24 @@
 # eRegs System Security Plan
 
+## Pushing to Cloud Foundry
+There is a simple way to pushing a non-production ready version of this to
+Cloud Foundry.
+
+Requirements:
+- A Docker Hub account
+  - Before running the script, run `docker login`.
+- A docker hub repo for the image.
+- The CloudFoundry CLI
+- A CloudFoundry platform that allows for docker images to be pushed.
+
+```
+# Usage
+# ./deploy-cf.sh <dockerhub repo> <app name>
+
+# Example
+$ ./deploy-cf.sh jcscottiii/ssperegs my-ssp-eregs
+```
+
 This is an experiment to render compliance documentation (as a System Security Plan) in the [eRegs](https://eregs.github.io/) platform. Follow [these instructions](docs/docker_setup.rst) to get it running.
 
 This was repository was forked from the [ATF eRegs](https://github.com/18F/atf-eregs) as of [`9d044a2`](https://github.com/opencontrol/eregs-ssp/tree/9d044a26f5bdfc50b3a242da7e2ce0a33bc8c07c). [View the diff.](https://github.com/opencontrol/eregs-ssp/compare/9d044a26f5bdfc50b3a242da7e2ce0a33bc8c07c...master)

--- a/atf_eregs/settings/base.py
+++ b/atf_eregs/settings/base.py
@@ -21,8 +21,7 @@ DATABASES = {
     )
 }
 
-API_BASE = 'http://localhost:{}/api/'.format(
-    os.environ.get('VCAP_APP_PORT', '8000'))
+API_BASE = 'http://localhost:8000/api/'
 
 STATICFILES_DIRS = ['compiled']
 

--- a/deploy-cf.sh
+++ b/deploy-cf.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+# This script assumes your Cloud Foundry platform allows for pushing
+# Dockerfiles.
+#
+# This script also assumes you have already logged into docker hub via
+# `docker login`.
+# It performs the following steps:
+# - Builds the image
+# - Pushes the image to docker hub
+# - Deploys the image from docker hub to Cloud Foundry.
+# - Calls the parser script to push data to the deployed app.
+#
+# The script needs two arguments:
+# 1) The Repo/Image name combination  (e.g. jcscottiii/ssperegs)
+# 2) The app name
+IMAGE=$1
+APP_NAME=$2
+docker build -f Dockerfile.cf -t $IMAGE
+docker push $IMAGE
+cf push $APP_NAME -o $IMAGE
+docker run -it -v $(pwd)/eregs_extensions:/app/extensions -v $(pwd)/input:/app/input --entrypoint="/app/extensions/docker-start-cf.sh" eregs/parser
+cf app $APP_NAME

--- a/deploy-cf.sh
+++ b/deploy-cf.sh
@@ -14,9 +14,10 @@
 # The script needs two arguments:
 # 1) The Repo/Image name combination  (e.g. jcscottiii/ssperegs)
 # 2) The app name
+set -e
 IMAGE=$1
 APP_NAME=$2
-docker build -f Dockerfile.cf -t $IMAGE
+docker build -f Dockerfile.cf -t $IMAGE .
 docker push $IMAGE
 cf push $APP_NAME -o $IMAGE
 docker run -it -v $(pwd)/eregs_extensions:/app/extensions -v $(pwd)/input:/app/input --entrypoint="/app/extensions/docker-start-cf.sh" eregs/parser

--- a/eregs_extensions/docker-start-cf.sh
+++ b/eregs_extensions/docker-start-cf.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+echo "LOCAL_XML_PATHS = ['/app/input/']" > local_settings.py
+./manage.py migrate
+eregs pipeline 27 646 https://my-ssp-eregs.fr.cloud.gov/api


### PR DESCRIPTION
The pushed app uses sqlite as a database so this is only for demo
purposes.
This script assumes your Cloud Foundry platform allows for pushing
Dockerfiles.
This script also assumes you have already logged into docker hub via
`docker login`.
It performs the following steps:
- Builds the image
- Pushes the image to docker hub
- Deploys the image from docker hub to Cloud Foundry.
- Calls the parser script to push data to the deployed app.
  The script needs two arguments:
  1) The Repo/Image name combination  (e.g. jcscottiii/ssperegs)
  2) The app name
